### PR TITLE
ci: update alpine version on envoy-alpine Dockerfile

### DIFF
--- a/ci/Dockerfile-envoy-alpine
+++ b/ci/Dockerfile-envoy-alpine
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc:alpine-3.12_glibc-2.31
+FROM frolvlad/alpine-glibc:alpine-3.13_glibc-2.32
 RUN mkdir -p /etc/envoy
 
 ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
Update alpine version on envoy-alpine Dockerfile in order to absorb the fix for CVE-2020-28928
Risk Level: Medium
Testing: Manual

Fixes #14869